### PR TITLE
validate connection to remote pods

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ENGINE ?= podman
 ORG ?= cloud-bulldozer
 REGISTRY ?= quay.io
 REG = $(REGISTRY)/$(ORG)
-REPOS = perfapp  etcd-perf nginx frr netpol-scraper nginxecho eipvalidator sampleapp
+REPOS = perfapp  etcd-perf nginx frr netpol-scraper nginxecho eipvalidator sampleapp netpolvalidator
 
 all: build push
 

--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ Container Images for OCP Perf&Scale
 - netpol-scraper: quay.io/cloud-bulldozer/netpol-scraper:latest
 - eipvalidator: quay.io/cloud-bulldozer/eipvalidator:latest
 - nginxecho: quay.io/cloud-bulldozer/nginxecho:latest
+- netpolvalidator: quay.io/cloud-bulldozer/netpolvalidator:latest

--- a/netpolvalidator/Containerfile
+++ b/netpolvalidator/Containerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+RUN microdnf install golang -y \
+    && microdnf clean all
+
+WORKDIR /app
+COPY go.mod  *.go ./
+RUN go mod download
+RUN go mod tidy
+RUN CGO_ENABLED=0 GOOS=linux go build -o /netpolvalidator
+EXPOSE 9001
+CMD ["/netpolvalidator"]

--- a/netpolvalidator/README.md
+++ b/netpolvalidator/README.md
@@ -1,0 +1,37 @@
+# Connection Testing and Latency Measurement for Network Policies Validation
+
+Kube-burner utilizes a client pod, built from this image, to send connections to designated server IPs. Kube-burner provides the client pod with multiple IP addresses, which the pod uses to send requests. Once a request is successfully processed, the client pod records the timestamp and sends this information back to Kube-burner. A proxy pod is employed by Kube-burner to facilitate communication between itself and the client pod.
+
+Key Details:
+
+- All client pods listen on port 9001 for incoming requests.
+- The Kube-burner proxy pod communicates with the client pod via the `/check` endpoint. This triggers the client pod to continuously send HTTP requests to the first three remote addresses from the connection list. Once any of these requests succeed, it confirms that the network policies have been applied, and then proceeds to send requests to all remaining connections.
+- To handle high volume and scale efficiently, the client pod uses 20 parallel Goroutines. Each Goroutine handles sending requests to 20 different IP addresses concurrently.
+- Each HTTP request is retried up to 3 times, with a timeout of 1.5 seconds per request.
+- If a request fails after 3 attempts, it is considered failed and added to a dedicated channel. A separate Goroutine monitors this channel and retries the failed requests.
+- Upon successful completion of a request, the timestamp is recorded for future reference.
+- Finally, the proxy pod gathers all the results from the client pod by querying the `/results` endpoint.
+
+Log from one of the client pods
+
+```shell
+$ oc logs -n network-policy-perf-0 -c curlapp test-pod-1 -f
+2024/10/01 10:39:17 Server started on 127.0.0.1:9001
+2024/10/01 10:39:34 Start sending Connections info 
+2024/10/01 10:39:34 Finished sending Connections info
+2024/10/01 10:39:34 Start waiting for Network policy object creation  [{10.128.2.44 8080 0 ingress-1-1 0001-01-01 00:00:00 +0000 UTC}]
+2024/10/01 10:39:34 Sending request to address 10.128.2.44
+2024/10/01 10:39:35 Error connecting to address 10.128.2.44 Get "http://10.128.2.44:8080": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+2024/10/01 10:39:36 Sending request to address 10.128.2.44
+2024/10/01 10:39:37 Error connecting to address 10.128.2.44 Get "http://10.128.2.44:8080": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+2024/10/01 10:39:37 Sending request to address 10.128.2.44
+2024/10/01 10:39:39 Error connecting to address 10.128.2.44 Get "http://10.128.2.44:8080": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+2024/10/01 10:39:39 Sending request to address 10.128.2.44
+2024/10/01 10:39:40 Error connecting to address 10.128.2.44 Get "http://10.128.2.44:8080": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+2024/10/01 10:39:40 Sending request to address 10.128.2.44
+2024/10/01 10:39:40 Got 200 response to address 10.128.2.44
+2024/10/01 10:39:40 Finished waiting for Network policy object creation 
+2024/10/01 10:39:41 Sending request to address 10.128.2.44
+2024/10/01 10:39:41 Got 200 response to address 10.128.2.44
+
+```

--- a/netpolvalidator/go.mod
+++ b/netpolvalidator/go.mod
@@ -1,0 +1,3 @@
+module example.com/netpolvalidator
+
+go 1.21.9

--- a/netpolvalidator/main.go
+++ b/netpolvalidator/main.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Used to gather connection information from kube-burner proxy pod
+type connection struct {
+	Addresses []string `json:"addresses"`
+	Ports     []int    `json:"ports"`
+	Netpol    string   `json:"netpol"`
+}
+
+var connections []connection
+
+// Local copy of connection information and also stores the result i.e succesful connection timestamp
+type connTest struct {
+	Address    string    `json:"address"`
+	Port       int       `json:"port"`
+	IngressIdx int       `json:"connectionidx"`
+	NpName     string    `json:"npname"`
+	Timestamp  time.Time `json:"timestamp"`
+}
+
+const parallelConnections = 20
+
+var (
+	resultsLock    sync.Mutex
+	connTestLock   sync.Mutex
+	results        = make([]connTest, 0)
+	wg             sync.WaitGroup
+	failedConnChan = make(chan connTest, 1000)
+	netpolTimeout  = time.Second * 10
+	httpClient     = http.Client{Timeout: 1500 * time.Millisecond}
+	gotConnectins  = make(chan bool)
+)
+
+var allConnTests []connTest
+
+func sendRequest(address string, port int) (bool, time.Time) {
+	url := fmt.Sprintf("http://%s:%d", address, port)
+	log.Printf("Sending request to address %s", address)
+	resp, err := httpClient.Get(url)
+	if err != nil {
+		log.Printf("Error connecting to address %v %v", address, err)
+		return false, time.Now().UTC()
+	}
+	defer resp.Body.Close()
+	log.Printf("Got %v response to address %s", resp.StatusCode, address)
+	return resp.StatusCode == http.StatusOK, time.Now().UTC()
+}
+
+// Send requests to provided addresses as part of connections.
+// Return succesful and failed connections
+func testConnections(connTests []connTest) ([]connTest, []connTest) {
+	var successConn []connTest
+	var failedConn []connTest
+	for _, ct := range connTests {
+		for attempt := 1; attempt <= 3; attempt++ {
+			success, timestamp := sendRequest(ct.Address, ct.Port)
+			if success {
+				ct.Timestamp = timestamp
+				successConn = append(successConn, ct)
+				break
+			} else if attempt == 3 {
+				failedConn = append(failedConn, ct)
+				log.Printf("failed request to %v after 3 attempts", ct.Address)
+			}
+		}
+	}
+	if len(successConn) > 0 {
+		resultsLock.Lock()
+		for _, conn := range successConn {
+			results = append(results, conn)
+		}
+		resultsLock.Unlock()
+	}
+	return successConn, failedConn
+}
+
+// This pod has to wait till kube-burner starts creating network policies.
+// To implement this wait, we test connections using first 3 network policies.
+// Once kube-burner starts running the job and creating network policies,
+// checking the 3 network policies will be succesful, then we exit the wait
+// and start processing all connections
+func waitForJobStarted(connTests []connTest) {
+	var jobStartConn map[string]connTest = make(map[string]connTest)
+	addConn := 1
+	success := false
+	for _, conn := range connTests {
+		if _, ok := jobStartConn[conn.NpName]; !ok {
+			jobStartConn[conn.NpName] = conn
+			if addConn == 3 {
+				break
+			}
+			addConn += 1
+		}
+	}
+	for {
+		for _, conn := range jobStartConn {
+			success, _ = sendRequest(conn.Address, conn.Port)
+			if success {
+				break
+			}
+		}
+		if success {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// Dedicated thread to test failed connections
+func processFailed() {
+	batchSize := 10
+	semaphore := make(chan struct{}, parallelConnections)
+	for {
+		batch := make([]connTest, 0, batchSize)
+		for i := 0; i < batchSize; i++ {
+			select {
+			case val := <-failedConnChan:
+				batch = append(batch, val)
+			default:
+				// No more data available, process what we have
+				break
+			}
+		}
+		if len(batch) > 0 {
+			semaphore <- struct{}{}
+			go func(batch []connTest, semaphore chan struct{}) {
+				defer func() { <-semaphore }()
+				_, failedConn := testConnections(batch)
+				if len(failedConn) > 0 {
+					for _, c := range failedConn {
+						failedConnChan <- c
+					}
+				}
+			}(batch, semaphore)
+		}
+		time.Sleep(100 * time.Millisecond) // Avoid tight loop
+	}
+}
+
+// Test sending requests to the provided addresses.
+// Move failed connections to a dedicated thread.
+func processIngress(connTests []connTest, semaphore chan struct{}, tc int) {
+	defer wg.Done()
+	defer func() { <-semaphore }()
+	done := make(chan bool, 1)
+	success := make(chan bool, 1)
+	testChan := make(chan []connTest, 1)
+	ticker := time.NewTicker(time.Second)
+	go func(threadCount int) {
+		var failedConn []connTest
+		for {
+			select {
+			case <-done:
+				testChan <- failedConn
+				return
+			case <-ticker.C:
+				_, failedConn = testConnections(connTests)
+				if len(failedConn) != len(connTests) {
+					testChan <- failedConn
+					success <- true
+					return
+				}
+			}
+		}
+	}(tc)
+	select {
+	case <-success:
+	case <-time.After(netpolTimeout):
+		log.Println("Timeout reached processing network policy.")
+	}
+	done <- true
+	ticker.Stop()
+	// retry failed conn in 3 attempts
+	failedConn := <-testChan
+	for attempt := 1; attempt <= 3; attempt++ {
+		_, failedConn = testConnections(failedConn)
+		if len(failedConn) == 0 {
+			break
+		}
+	}
+	// if still they fail move them to another thread
+	if len(failedConn) > 0 {
+		for _, c := range failedConn {
+			failedConnChan <- c
+		}
+	}
+}
+
+// Return the results to kube-burner proxy pod
+func resultsHandler(w http.ResponseWriter, r *http.Request) {
+	resultsLock.Lock()
+	defer resultsLock.Unlock()
+	if err := json.NewEncoder(w).Encode(results); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// Get connections from kube-burner proxy pod and create a local copy of
+// this information.
+func handleRequest(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprintln(w, "Check Request received, processing...")
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "Unable to read request body", http.StatusBadRequest)
+		return
+	}
+
+	err = json.Unmarshal(body, &connections)
+	if err != nil {
+		http.Error(w, "Unable to parse request body", http.StatusBadRequest)
+		return
+	}
+	log.Println("Start sending Connections info ")
+	for connectionIdx, connection := range connections {
+		for _, address := range connection.Addresses {
+			for _, port := range connection.Ports {
+				allConnTests = append(allConnTests, connTest{Address: address, Port: port, IngressIdx: connectionIdx, NpName: connection.Netpol})
+			}
+		}
+	}
+	r.Body.Close()
+	log.Println("Finished sending Connections info")
+	gotConnectins <- true
+}
+
+// function to process connections
+func sendRequests() {
+	// Wait till we get connections from kube-burner proxy pod
+	<-gotConnectins
+	// Wait till kube-burner creates job's objects
+	log.Println("Start waiting for Network policy object creation ", allConnTests)
+	waitForJobStarted(allConnTests)
+	log.Println("Finished waiting for Network policy object creation ")
+	// Start a dedicated thread for processing failed connections
+	go processFailed()
+	// Use 20 parallel threads for connection testing.
+	// Each thread will process 20 requests
+	semaphore := make(chan struct{}, parallelConnections)
+	for i := 0; i < len(allConnTests); i += parallelConnections {
+		end := i + parallelConnections
+		if end > len(allConnTests) {
+			end = len(allConnTests)
+		}
+		semaphore <- struct{}{}
+		wg.Add(1)
+		go processIngress(allConnTests[i:end], semaphore, i)
+
+	}
+	wg.Wait()
+}
+
+func main() {
+	go sendRequests()
+	http.HandleFunc("/check", handleRequest)
+	http.HandleFunc("/results", resultsHandler)
+	log.Println("Server started on 127.0.0.1:9001")
+	go func() {
+		log.Fatal(http.ListenAndServe(":9001", nil))
+	}()
+
+	select {} // Keep the server running
+}


### PR DESCRIPTION
## Type of change

- [x] New feature

## Description

validate allowed network policy connections to remote pods by sending http requests


## Related Tickets & Documents
https://github.com/kube-burner/kube-burner/pull/679