### PR TITLE
env var for threads

### DIFF
--- a/netpolvalidator/main.go
+++ b/netpolvalidator/main.go
@@ -6,6 +6,8 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -28,7 +30,7 @@ type connTest struct {
 	Timestamp  time.Time `json:"timestamp"`
 }
 
-const parallelConnections = 20
+var parallelConnections = 10
 
 var (
 	resultsLock    sync.Mutex
@@ -259,7 +261,19 @@ func sendRequests() {
 	wg.Wait()
 }
 
+func processEnvVars() {
+	var err error
+	parallelConnectionsStr := os.Getenv("PARALLEL_CONNECTIONS")
+	if parallelConnectionsStr != "" {
+		parallelConnections, err = strconv.Atoi(parallelConnectionsStr)
+		if err != nil {
+			panic(fmt.Sprintf("failed to parse env PARALLEL_CONNECTIONS: %v", err))
+		}
+	}
+}
+
 func main() {
+	processEnvVars()
 	go sendRequests()
 	http.HandleFunc("/check", handleRequest)
 	http.HandleFunc("/results", resultsHandler)


### PR DESCRIPTION
1) Use env variable for parallel connections testing. 2) Default value is changed from 20 to 10 to avoid higher cpu usage by the client pods. We got similar connection latency with both 10 and 20 threads.
3) Now the user can define their own number of threads if needed when creating the client pods using the env variable.

