### PR TITLE
Build only amd64 platform foreman-cli repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,12 @@ name: cloud-bulldozer
 on:
   push:
     branches: [ main ]
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches: [ main ]
+    paths-ignore:
+    - '**.md'
 
 jobs:
 
@@ -16,10 +22,16 @@ jobs:
       run: sudo apt-get update || true && sudo apt-get install -y qemu-user-static podman fuse-overlayfs
 
     - name: Login in quay
+      if: github.event_name == 'push'
       run: podman login quay.io -u ${QUAY_USER} -p ${QUAY_TOKEN}
       env:
         QUAY_USER: ${{ secrets.QUAY_USER }}
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
 
-    - name: Build binary and push containers
+    - name: Build containers only (PR)
+      if: github.event_name == 'pull_request'
+      run: make build
+
+    - name: Build and push containers (main branch)
+      if: github.event_name == 'push'
       run: make 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,11 @@ all: build push
 build:
 	@for repo in $(REPOS); do \
 	  echo -e "\033[2mBuilding $$repo\033[0m"; \
-	  $(ENGINE) build --jobs=4 --platform=$(PLATFORMS) --manifest=$(REG)/$$repo:latest $$repo; \
+	  if [ "$$repo" = "foreman-cli" ]; then \
+	    $(ENGINE) build --jobs=4 --platform=linux/amd64 --manifest=$(REG)/$$repo:latest $$repo; \
+	  else \
+	    $(ENGINE) build --jobs=4 --platform=$(PLATFORMS) --manifest=$(REG)/$$repo:latest $$repo; \
+	  fi; \
 	done
 
 push:


### PR DESCRIPTION
## Type of change

- [ ] Refactor
- [ ] New feature
- [x ] Bug fix
- [ x] Optimization
- [ ] Documentation Update

## Description

Build only amd64 platform foreman-cli repo as there are only x86_64 repos in https://yum.theforeman.org/releases/3.15/el9/ and builds for other platforms fail.
See https://github.com/cloud-bulldozer/images/actions/runs/16726796233/job/47344465300 for reference

In addition extend the GH workflow to run make build on every pull request before merge.

